### PR TITLE
*Fix separators not being passed into internal methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Also, check out dpath.util.merge. The python dict update() method is great and a
     >>> help(dpath.util.merge)
     Help on function merge in module dpath.util:
 
-    merge(dst, src, filter=None, flags=4, _path='')
+    merge(dst, src, afilter=None, flags=4, _path='')
         Merge source into destination. Like dict.update() but performs
         deep merging.
 
@@ -252,7 +252,7 @@ Now that's handy. You shouldn't try to use this as a replacement for the deepcop
 Filtering
 =========
 
-All of the methods in this library (except new()) support a 'filter' argument. This can be set to a function that will return True or False to say 'yes include that value in my result set' or 'no don't include it'.
+All of the methods in this library (except new()) support a 'afilter' argument. This can be set to a function that will return True or False to say 'yes include that value in my result set' or 'no don't include it'.
 
 Filtering functions receive every terminus node in a search - e.g., anything that is not a dict or a list, at the very end of the path. For each value, they return True to include that value in the result set, or False to exclude it.
 
@@ -274,12 +274,12 @@ Consider this example. Given the source dictionary, we want to find ALL keys ins
 	    }
 	}
     }
-    >>> def filter(x):
+    >>> def afilter(x):
     ...     if "ffle" in str(x):
     ...             return True
     ...     return False
     ...
-    >>> result = dpath.util.search(x, '**', filter=filter)
+    >>> result = dpath.util.search(x, '**', afilter=afilter)
     >>> print json.dumps(result, indent=4, sort_keys=True)
     {
 	"a": {
@@ -300,6 +300,6 @@ Obviously filtering functions can perform more advanced tests (regular expressio
 dpath.path : The Undocumented Backend
 =====================================
 
-dpath.util is where you want to spend your time: this library has the friendly functions that will understand simple string globs, filter functions, etc.
+dpath.util is where you want to spend your time: this library has the friendly functions that will understand simple string globs, afilter functions, etc.
 
 dpath.path is the backend pathing library - it is currently undocumented, and not meant to be used directly! It passes around lists of path components instead of string globs, and just generally does things in a way that you (as a frontend user) might not expect. Stay out of it. You have been warned!

--- a/dpath/path.py
+++ b/dpath/path.py
@@ -83,14 +83,14 @@ def paths(obj, dirs=True, leaves=True, path=[], skip=False, separator="/"):
             validate(newpath, separator=separator)
             if dirs:
                 yield newpath
-            for child in paths(v, dirs, leaves, newpath, skip):
+            for child in paths(v, dirs, leaves, newpath, skip, separator=separator):
                 yield child
     elif isinstance(obj, (list, tuple)):
         for (i, v) in enumerate(obj):
             newpath = path + [[i, v.__class__]]
             if dirs:
                 yield newpath
-            for child in paths(obj[i], dirs, leaves, newpath, skip):
+            for child in paths(obj[i], dirs, leaves, newpath, skip, separator=separator):
                 yield child
     elif leaves:
         yield path + [[obj, obj.__class__]]
@@ -132,7 +132,7 @@ def match(path, glob):
 def is_glob(string):
     return any([c in string for c in '*?[]!'])
 
-def set(obj, path, value, create_missing=True, separator="/", filter=None):
+def set(obj, path, value, create_missing=True, separator="/", afilter=None):
     """Set the value of the given path in the object. Path
     must be a list of specific path elements, not a glob.
     You can use dpath.util.set for globs, but the paths must
@@ -216,10 +216,10 @@ def set(obj, path, value, create_missing=True, separator="/", filter=None):
 
     if elem is None:
         return
-    if (filter and filter(accessor(obj, elem))) or (not filter):
+    if (afilter and afilter(accessor(obj, elem))) or (not afilter):
         assigner(obj, elem, value)
 
-def get(obj, path, view=False, filter=None):
+def get(obj, path, view=False, afilter=None):
     """Get the value of the given path.
 
     Arguments:
@@ -259,7 +259,7 @@ def get(obj, path, view=False, filter=None):
                 tail = tail[-1]
 
         if not issubclass(target.__class__, (list, dict)):
-            if (filter and (not filter(target))):
+            if (afilter and (not afilter(target))):
                 raise dpath.exceptions.FilteredValue
 
         index += 1

--- a/tests/test_path_get.py
+++ b/tests/test_path_get.py
@@ -16,3 +16,4 @@ def test_path_get_list_of_dicts():
     assert(isinstance(res['a']['b'], list))
     assert(len(res['a']['b']) == 1)
     assert(res['a']['b'][0][0] == 0)
+

--- a/tests/test_util_delete.py
+++ b/tests/test_util_delete.py
@@ -30,7 +30,7 @@ def test_delete_missing():
     dpath.util.delete(dict, '/a/b')
 
 def test_delete_filter():
-    def filter(x):
+    def afilter(x):
         if int(x) == 31:
             return True
         return False
@@ -42,7 +42,7 @@ def test_delete_filter():
             "d": 31
             }
         }
-    dpath.util.delete(dict, '/a/*', filter=filter)
+    dpath.util.delete(dict, '/a/*', afilter=afilter)
     assert (dict['a']['b'] == 0)
     assert (dict['a']['c'] == 1)
     assert ('d' not in dict['a'])

--- a/tests/test_util_merge.py
+++ b/tests/test_util_merge.py
@@ -77,7 +77,7 @@ def test_merge_simple_dict():
     nose.tools.eq_(dst["dict"]["key"], src["dict"]["key"])
 
 def test_merge_filter():
-    def filter(x):
+    def afilter(x):
         if "rubber" not in str(x):
             return False
         return True
@@ -90,7 +90,7 @@ def test_merge_filter():
             }
         }
     dst = {}
-    dpath.util.merge(dst, src, filter=filter)
+    dpath.util.merge(dst, src, afilter=afilter)
     assert ("key2" in dst)
     assert ("key" not in dst)
     assert ("otherdict" not in dst)

--- a/tests/test_util_search.py
+++ b/tests/test_util_search.py
@@ -47,8 +47,10 @@ def test_search_paths():
     for (path, value) in dpath.util.search(dict, '/**', yielded=True):
         assert(path in paths)
 
-def test_search_filter():
-    def filter(x):
+def test_search_afilter():
+    import json
+
+    def afilter(x):
         if x in [1, 2]:
             return True
         return False
@@ -69,9 +71,10 @@ def test_search_filter():
         'a/b/c/e',
         'a/b/c/f'
         ]
-    for (path, value) in dpath.util.search(dict, '/**', yielded=True, filter=filter):
+    for (path, value) in dpath.util.search(dict, '/**', yielded=True, afilter=afilter):
         assert(path in paths)
-    assert("view_failure" not in dpath.util.search(dict, '/**', filter=filter)['a'])
+    assert("view_failure" not in dpath.util.search(dict, '/**', afilter=afilter)['a'])
+    assert("d" not in dpath.util.search(dict, '/**', afilter=afilter)['a']['b']['c'])
 
 def test_search_globbing():
     dict = {

--- a/tests/test_util_set.py
+++ b/tests/test_util_set.py
@@ -29,7 +29,7 @@ def test_set_existing_list():
     assert(dict['a'][0] == 1)
 
 def test_set_filter():
-    def filter(x):
+    def afilter(x):
         if int(x) == 31:
             return True
         return False
@@ -41,7 +41,7 @@ def test_set_filter():
             "d": 31
             }
         }
-    dpath.util.set(dict, '/a/*', 31337, filter=filter)
+    dpath.util.set(dict, '/a/*', 31337, afilter=afilter)
     print dict
     assert (dict['a']['b'] == 0)
     assert (dict['a']['c'] == 1)


### PR DESCRIPTION
*Fix search function with yield not returning anything if looking for an item that is along the way/not a final item in the object.
*Modify filtering hardcode in search function so that the paths function never returns paths along the way and only returns paths leading to final values.
*Change filtering 'filter' parameter to 'afilter' as 'filter' is a reserved in-built symbol. Update documentation to match.
