### PR TITLE
Handling the case where key is empty in dpath search

### DIFF
--- a/dpath/path.py
+++ b/dpath/path.py
@@ -77,6 +77,8 @@ def paths(obj, dirs=True, leaves=True, path=[], skip=False, separator="/"):
     """
     if isinstance(obj, dict):
         for (k, v) in obj.iteritems():
+            if not k:
+                continue
             if issubclass(k.__class__, (basestring)) and skip and k[0] == '+':
                 continue
             newpath = path + [[k, v.__class__]]


### PR DESCRIPTION
In our project, we had empty key that was causing dpath search to fail all together. since, the line  
`if issubclass(k.__class__, (basestring)) and skip and k[0] == '+':`
checking for k[0] without validating k is empty or not.

Just skipping for the case where key is empty. Nothing else is touch upon.

<!---
@huboard:{"custom_state":""}
-->
