### PR TITLE
Leaf

### DIFF
--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from datetime import datetime
 from dpath.exceptions import InvalidGlob, InvalidKeyName, PathNotFound
 from dpath import options
 from fnmatch import fnmatchcase
@@ -22,7 +23,7 @@ def leaf(thing):
 
     leaf(thing) -> bool
     '''
-    leaves = (bytes, str, int, float, bool, type(None))
+    leaves = (bytes, str, int, float, bool, type(None), datetime)
 
     return isinstance(thing, leaves)
 

--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from dpath.exceptions import InvalidGlob, InvalidKeyName, PathNotFound
 from dpath import options
 from fnmatch import fnmatchcase
+import six
 
 
 def kvs(node):

--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -25,8 +25,10 @@ def leaf(thing):
 
     leaf(thing) -> bool
     '''
-    return not isinstance(thing, collections.abc.Container) or isinstance(
-        thing, six.string_types
+    return (
+        not isinstance(thing, collections.abc.Container)
+        or isinstance(thing, six.string_types)
+        or isinstance(thing, six.binary_type)
     )
 
 

--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -1,3 +1,4 @@
+import collections
 from copy import deepcopy
 from datetime import datetime
 from dpath.exceptions import InvalidGlob, InvalidKeyName, PathNotFound

--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -23,9 +23,9 @@ def leaf(thing):
 
     leaf(thing) -> bool
     '''
-    leaves = (bytes, str, int, float, bool, type(None), datetime)
-
-    return isinstance(thing, leaves)
+    return not isinstance(thing, collections.abc.Container) or isinstance(
+        thing, six.string_types
+    )
 
 
 def leafy(thing):

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -1,3 +1,5 @@
+import datetime
+import decimal
 from dpath import options
 from hypothesis import given, assume, settings, HealthCheck
 import dpath.segments as api
@@ -339,3 +341,20 @@ def test_view(walkable):
 
     view = api.view(node, segments)
     assert api.get(view, segments) == api.get(node, segments)
+
+
+def test_leaves_passed():
+    '''
+    Test if a value is correctly classified as a leaf
+    '''
+    for thing in [
+        'a', 1, True, None, datetime.datetime(2020, 1, 1), decimal.Decimal(1.99)]:
+        assert api.leaf(thing) == True
+
+
+def test_leaves_failed():
+    '''
+    Test if a value is correctly classified as a leaf
+    '''
+    for thing in ['a', 1, True, None, datetime.datetime(2020, 1, 1)]:
+        assert api.leaf(thing) == True

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -1,10 +1,13 @@
 import datetime
 import decimal
-from dpath import options
-from hypothesis import given, assume, settings, HealthCheck
-import dpath.segments as api
-import hypothesis.strategies as st
 import os
+
+import dpath.segments as api
+from dpath import options
+
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, assume, given, settings
+
 
 settings.register_profile("default", suppress_health_check=(HealthCheck.too_slow,))
 settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'default'))
@@ -348,7 +351,13 @@ def test_leaves_passed():
     Test if a value is correctly classified as a leaf
     '''
     for thing in [
-        'a', 1, True, None, datetime.datetime(2020, 1, 1), decimal.Decimal(1.99)]:
+        'a',
+        1,
+        True,
+        None,
+        datetime.datetime(2020, 1, 1),
+        decimal.Decimal(1.99)
+    ]:
         assert api.leaf(thing) == True
 
 
@@ -356,5 +365,5 @@ def test_leaves_failed():
     '''
     Test if a value is correctly classified as a leaf
     '''
-    for thing in ['a', 1, True, None, datetime.datetime(2020, 1, 1)]:
-        assert api.leaf(thing) == True
+    for thing in [set(), [], {'cat': 'dog'}]:
+        assert api.leaf(thing) == False

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     hypothesis
     mock
     nose
+    six
 commands = nosetests {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
Expand the logic for what counts as a leaf, since the current code only accepts `bytes, str, int, float, bool, type(None)`

For instance, when parsing a YAML or JSON, datetimes are serialized and would not be counted as a leaf. 