### PR TITLE
fix json indentation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,10 +159,10 @@ value 'Waffles'.
     {
         "a": {
             "b": {
-            "3": 2,
-            "43": 30,
-            "c": "Waffles",
-            "d": "Waffles"
+                "3": 2,
+                "43": 30,
+                "c": "Waffles",
+                "d": "Waffles"
             }
         }
     }


### PR DESCRIPTION
Had a few puzzling seconds why the library works this way then I noticed I missed the missing indentation and that json obj is actually under `"b"`.