### PR TITLE
change leaf boolean function to exclude non-leaves

### DIFF
--- a/dpath/segments.py
+++ b/dpath/segments.py
@@ -23,8 +23,8 @@ def leaf(thing):
     leaf(thing) -> bool
     '''
     leaves = (bytes, str, int, float, bool, type(None))
-
-    return isinstance(thing, leaves)
+    non_leaves = (list, dict)
+    return not isinstance(thing, non_leaves)
 
 
 def leafy(thing):


### PR DESCRIPTION
I ran into a situation where dpath.util.merge did not allow me to merge dictionaries containing non-standard nodes (e.g. like datetime.date constructed by yaml loader).
So I propose an approach excluding non-leaves (list, dict)