### PR TITLE
docs: fix simple typo, communcate -> communicate

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ There are several individuals in the community who have taken an active role in 
 Where and How do we communicate
 ===============================
 
-The dpath maintainers communcate in 3 primary ways:
+The dpath maintainers communicate in 3 primary ways:
 
 1. Email, directly to each other.
 2. Github via issue and pull request comments


### PR DESCRIPTION
There is a small typo in MAINTAINERS.md.

Should read `communicate` rather than `communcate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md