### PR TITLE
Add ability to select path segments with user defined match; follow on to PRs #146 & #177

### DIFF
--- a/.github/workflows/linterTest.yml
+++ b/.github/workflows/linterTest.yml
@@ -1,0 +1,56 @@
+name: LinterTest
+    # ------------------------------------------------------------
+    # (C) Alain Lichnewsky, 2021
+    #
+    # For running under Github's Actions
+    #
+    # Script performs basic static test of the package under Python-3,
+    # including added functionality.
+    # ------------------------------------------------------------
+
+# Controls when the action will run.
+on:
+  #
+  ## Not enabled, would triggers the workflow on push or pull request events but
+  ## only for the AL-addRegexp branch.
+  #push:
+  #  branches: [ AL-addRegexp ]
+
+  # Allows to run this workflow manually from the Github Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in
+# parallel
+jobs:
+  # This workflow contains a single job called "super-lint"
+  super-lint:
+    # Steps represent a sequence of tasks that will be executed by the job
+    # Name the Job
+    name: Lint code base
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell, in practice it is useful
+      # to figure out some of the environment setup
+      - name: Use shell to figure out environment
+        run: echo Hello from Github Actions !!;
+             bash --version | head -1 ;
+             echo LANG=${LANG} SHELL=${SHELL} ;
+             echo PATH=${PATH}  ;
+             pwd;
+             ls -ltha;
+
+      # Runs the Super-Linter action
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+      #
+      # this script requires some environment variables
+      #
+        env:
+          DEFAULT_BRANCH: AL-addRegexp
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python3-pypy-Test.yml
+++ b/.github/workflows/python3-pypy-Test.yml
@@ -1,0 +1,121 @@
+name: Test python package dpath-python with regexp ext and pypy
+    # ------------------------------------------------------------
+    # (C) Alain Lichnewsky, 2021, 2022
+    #
+    # For running under Github's Actions
+    #
+    # Here the idea is to use tox for testing and test on python 3.8 and
+    # pypy-3.7.
+    #
+    # ------------------------------------------------------------
+
+on:
+    # manual dispatch, this script will not be started automagically
+    workflow_dispatch:
+
+jobs:
+    test-python3:
+
+        timeout-minutes: 60
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@main
+
+            - name: Set up Python 3.10
+              uses: actions/setup-python@main
+              with:
+                  python-version: '3.10'
+                  architecture: 'x64'
+
+            - name: Set up Pypy
+              uses: actions/setup-python@main
+              with:
+                  python-version: 'pypy3.9'
+                  architecture: 'x64'
+
+
+            - name: Ascertain configuration
+              shell: bash
+              #
+              #    Collect information concerning $HOME and the location of
+              #    file(s) loaded from Github/
+              run: |
+                echo Working dir: $(pwd)
+                echo Files at this location:
+                ls -ltha
+                echo HOME: ${HOME}
+                echo LANG: ${LANG}  SHELL: ${SHELL}
+                which python
+                echo LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}
+                echo PYTHONPATH: \'${PYTHONPATH}\'
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #    ** here (it is expected that) **
+              #  pythonLocation: /opt/hostedtoolcache/Python/3.8.8/x64
+              #  LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.8/x64/lib
+              #  Working dir /home/runner/work/dpath-python/dpath-python
+              #  HOME: /home/runner
+              #  LANG: C.UTF-8
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+            - name: Install dependencies
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #  requirements install the test framework, which is not
+              #  required by the package in setup.py
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              shell: bash
+              run: |
+                python -m pip install --upgrade pip setuptools wheel
+                if [ -f requirements.txt ]; then
+                   pip install -r requirements.txt;
+                fi
+                python -m pip install --upgrade nose2 rapidfuzz hypothesis
+                python setup.py install
+                echo which nose :$(which nose)
+                echo which nose2: $(which nose2)
+                echo which nose2-3.6: $(which nose2-3.6)
+                echo which nose2-3.8: $(which nose2-3.8)
+
+            - name: Check path preparing for pypy (1)
+              shell: bash
+              if: always()
+              run: |
+                test-utils/py_path_checker -M nose2 -U
+
+            - name: Check path preparing for pypy (2)
+              shell: bash
+              if: always()
+              run: |
+                pypy3 test-utils/py_path_checker -M nose2 -U
+
+            - name: Perform python tests
+              shell: bash
+              if: always()
+              run: |
+                PYTHONPATH="." test-utils/nose_runner -E -s tests
+
+            - name: Perform pypy tests
+              shell: bash
+              if: always()
+              run: |
+                PYTHONPATH=".:/usr/local/lib/python3.10/dist-packages/" \
+                      pypy3 test-utils/nose_runner -E -s tests
+
+
+            - name: Tox testing
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #  move to tox testing, otherwise will have to parametrize
+              #  nose in more details; here tox.ini will apply
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              shell: bash
+              if: always()
+              run: |
+                pip install tox
+                echo "Installed tox"
+                tox
+                echo "Ran tox"

--- a/.github/workflows/python3Test.yml
+++ b/.github/workflows/python3Test.yml
@@ -1,0 +1,98 @@
+name: Test python package dpath-python with regexp extension
+  # ------------------------------------------------------------
+  # (C) Alain Lichnewsky, 2021, 2022
+  #
+  # For running under Github's Actions
+  #
+  # Script performs basic test of the Python-3 version of the package
+  # including added functionality (regexp in search paths).
+  # ------------------------------------------------------------
+
+on:
+    workflow_dispatch:
+    # Allows manual dispatch from the Actions tab
+
+jobs:
+    test-python3:
+
+        timeout-minutes: 60
+
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                # Match versions specified in tox.ini
+                python-version: ['3.10', 'pypy3.9']
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@main
+
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@main
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  architecture: 'x64'
+
+            - name: Ascertain configuration
+              #
+              #    Collect information concerning $HOME and the location of
+              #    file(s) loaded from Github/
+              run: |
+                echo Working dir: $(pwd)
+                echo Files at this location:
+                ls -ltha
+                echo HOME: ${HOME}
+                echo LANG: ${LANG}  SHELL: ${SHELL}
+                which python
+                echo LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}
+                echo PYTHONPATH: \'${PYTHONPATH}\'
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #    ** here (it is expected that) **
+              #  pythonLocation: /opt/hostedtoolcache/Python/3.8.8/x64
+              #  LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.8/x64/lib
+              #  Working dir /home/runner/work/dpath-python/dpath-python
+              #  HOME: /home/runner
+              #  LANG: C.UTF-8
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+            - name: Install dependencies
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #  requirements install the test framework, which is not
+              #  required by the package in setup.py
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              run: |
+                python -m pip install --upgrade pip setuptools wheel \
+                        nose2 hypothesis rapidfuzz
+                if [ -f requirements.txt ]; then
+                   pip install -r requirements.txt;
+                fi
+                python setup.py install
+                echo which nose :$(which nose)
+                echo which nose2: $(which nose2)
+                echo which nose2-3.6: $(which nose2-3.6)
+                echo which nose2-3.8: $(which nose2-3.8)
+
+            - name: nose_runner testing
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #  This is the nose2 wrapper that allows to set pgm. parms
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+              run: |
+                echo running the nose2 wrapper
+                PYTHONPATH="." test-utils/nose_runner -E  -s tests
+
+            - name: Tox testing
+
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              #  move to tox testing, otherwise will have to parametrize
+              #  nose in more details; here tox.ini will apply
+              #  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+              run: |
+                pip install tox
+                echo "Installed tox"
+                tox
+                echo "Ran tox"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ venv_39
 dpath.egg-info/
 dist/
 tests/.hypothesis
+
+# Github logs
+.githubLogs
+
+# Test etc
+.coverage
+
+# Editor temporaries
+*~
+ 

--- a/buildTools/pypy-test
+++ b/buildTools/pypy-test
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# ......................................................................
+#  Function :
+#          - check pypy installation
+#          - run pypy test
+#
+#
+#   Normally used/called by devel-Steps -y.
+#
+#   Generalization;
+#      This proc does not know about installation parameters... files
+#      and directories need to be passes explicitely
+# ......................................................................
+#
+#  (C) Alain Lichnewsky, 2022
+#
+# ......................................................................
+trap 'status=$?; echo "error status is $status"; trap - EXIT; exit $status' ERR
+SCRIPTPATH=$(dirname $(realpath $0))
+SCRIPTNAME=$(basename $(realpath $0))
+
+# ......................................................................
+# Configurables
+# ......................................................................
+PYPY=pypy3
+# ......................................................................
+
+
+function requireApproval () {
+    question="$1"
+    ok="YyOo"
+    notOK="nN"
+    pattern="[oOyY]"
+    prompt="Answer [${ok}]? "
+    count=0
+
+    echo "$question"
+    read -p "${prompt}" -n 1 inchar
+    while (( $count < 4 )) ; do
+	if [[ "$inchar" =~ $pattern ]] ; then
+	    echo ""
+	    return
+	else
+	    exit 1
+	fi
+	count=$(( 1 + $count))
+    done
+    exit 1
+}
+
+function run_pypy () {
+    declare -r target="$1"
+    declare -r pythonpath="$2"
+
+    pythonpath2="${pythonpath}:${HOME}/.local/lib/python3.10/site-packages/:/usr/local/lib/python3.10/dist-packages/" 
+    #pythonpath2="${pythonpath2}:/usr/lib/python3.10/:/usr/lib/python3.11/"
+    pythonpath2="${pythonpath2}:/usr/local/lib/python3.10/dist-packages/:/usr/local/lib/python3.11/dist-packages/"
+
+    export PYTHONPATH="${pythonpath2}" 
+
+    echo ${ECHO} PYTHONPATH="${pythonpath2}"
+    ${ECHO} ${PYPY} ${runPdb} ${target} ${@: 3} 
+}
+
+function usage() {
+  less >/dev/stderr <<EOF
+usage:
+    ${0} [-h|-d|-v] [-t <target>] [-r <option>] 
+
+Function:
+    -h         : print this help
+    -v         : verbose mode
+    -d         : debug mode: echo commands instead of executing (env. ECHO) 
+    -P         : run the Python Debugger pdb
+    -r <target> : run pypy on target
+
+EOF
+  exit 1
+}
+
+doProc="default"
+while getopts "dhvr:P" opt; do
+    foundOpt=1
+    case "$opt" in
+    d)  verbose=1 ;
+        ECHO=echo 	    
+        ;;
+    h|\?)
+        usage
+        ;;
+    r) runtarget="${OPTARG}"
+        doProc=runPypy
+        ;;
+
+    P) runPdb="-m pdb"
+        ;;
+
+    -)  echo found --
+        xmit_eol=1
+        break
+        ;;
+
+   *)  # redundant clause if getopts is totally selective
+	    echo Incorrect argument "$opt" >/dev/stderr
+	    exit 2
+    esac
+done  
+
+if [ "${foundOpt}" == "" ] ; then
+    echo Incorrect command line, one of the flags is required
+    usage
+    exit 1
+fi
+
+# see bash manual for "getopts" function, OPTIND is positioned to
+# index of first positional argument
+if [ $OPTIND -le $# ] ; then
+       supplem_args="${@: ${OPTIND} }"
+fi
+
+case "${doProc}" in
+    runPypy)
+        echo running pypy
+        run_pypy "${runtarget}" "${HOME}/dpath-source" ${supplem_args}
+        ;;
+    *)
+        echo unexpected command \"${doProc}\" 
+	    exit 1
+        ;;
+esac
+   

--- a/dpath/options.py
+++ b/dpath/options.py
@@ -1,1 +1,63 @@
+""" The module dpath.options defines
+    - ALLOW_EMPTY_STRING_KEYS
+    - PATH_ACCEPT_RE_REGEXP  : permits selection of option to accept regular
+                               expressions in paths
+    - PEP544_PROTOCOL_AVAILABLE: the language processor permits duck typing
+                             PEP-0544
+    - ISINSTANCE_ACCEPTS_UNIONS: isinstance can use types which are Unions
+    - (Internal) DEBUG_PRINT : select additional printout from environment
+                               PYTHON_DPATH_DEBUG
+"""
+from sys import stderr
+from os import getenv
+from typing import Union
+
+DEBUG_PRINT = True if getenv("PYTHON_DPATH_DEBUG") is not None else False
+
 ALLOW_EMPTY_STRING_KEYS = False
+
+# extension disabled by default to preserve backwards compatibility
+#
+DPATH_ACCEPT_RE_REGEXP = False
+
+# --------------------------------------------------------------------
+# Language processor variations
+# --------------------------------------------------------------------
+
+# Enable usage of PEP544 / typing.Protocol if available
+# see https://peps.python.org/pep-0544/
+# this allows usage of typing module's:
+#       Protocol, runtime_checkable
+#  and from abc: abstractmethod
+# We made the choice of discovering by testing in a try block;
+# the may then use dpath.options.PEP544_PROTOCOL_AVAILABLE to figure out
+
+try:
+    from typing import Protocol
+    PEP544_PROTOCOL_AVAILABLE = True
+except Exception:
+    PEP544_PROTOCOL_AVAILABLE = False
+
+# Using Unions of types in isinstance is also an issue
+# https://peps.python.org/pep-0604/#isinstance-and-issubclass
+# https://bugs.python.org/issue44529
+
+try:
+    _PS = Union[int, str]
+    a = isinstance(2, _PS)
+    ISINSTANCE_ACCEPTS_UNIONS = True
+    if DEBUG_PRINT:
+        print(f"OK for isinstance with Unions: returns {a}", file=stderr)
+except Exception as err:
+    ISINSTANCE_ACCEPTS_UNIONS = False
+    if DEBUG_PRINT:
+        print(f"NOT OK for isinstance with Unions: {err}", file=stderr)
+
+
+def isinstance_ext(o, t):
+    """ allows to use Unions as insinstance reference type
+    """
+    if (type(t) == type(Union[str, int])) and not ISINSTANCE_ACCEPTS_UNIONS:
+        return any(map(lambda x: isinstance(o, x), t))
+
+    return isinstance(o, t)

--- a/dpath/types.py
+++ b/dpath/types.py
@@ -1,6 +1,19 @@
 from enum import IntFlag, auto
 from typing import Union, Any, Callable, Sequence, Tuple, List, Optional, MutableMapping
 
+from dpath.options import PEP544_PROTOCOL_AVAILABLE
+
+if PEP544_PROTOCOL_AVAILABLE:
+    try:
+        # Use PEP544 for Duck Typing specs
+        from typing import Protocol, runtime_checkable
+        from abc import abstractmethod
+    except Exception:
+        PEP544_PROTOCOL_AVAILABLE = False
+
+# For re.regexp string match
+import re
+
 
 class SymmetricInt(int):
     """Same as a normal int but mimicks the behavior of list indexes (can be compared to a negative number)."""
@@ -54,7 +67,60 @@ Filter = Callable[[Any], bool]
 
 (Any) -> bool"""
 
-Glob = Union[str, Sequence[str]]
+
+class Basic_StringMatcher:
+    """ Empty version of base class to be used when typing.Protocol is not
+            available. In this case, a derived class defining match can be
+            used to match path components. (see examples)
+    """
+
+    def __init__(self):
+        raise RuntimeError("This is a pseudo abstract class")
+
+    def match(self, str):
+        raise NotImplementedError
+
+
+if PEP544_PROTOCOL_AVAILABLE:
+    @runtime_checkable
+    class Duck_StringMatcher(Protocol):
+        """ Facilitate match component matching using duck typing (see examples)
+           Uses PEP 544: Protocols: Structural subtyping (static duck typing)
+           to define requirements for a string matcher that can be used in
+           an extended glob.
+
+           Requirement:
+            - match(str) -> Optional (Object)
+        """
+        @abstractmethod
+        def match(self, str) -> Optional[object]:
+            """ Requirement for match function, must return None if matching
+            rejected. False is not a rejection !
+            """
+            # Method without a default implementation
+            raise NotImplementedError
+
+    StringMatcher = Union[re.Pattern, Duck_StringMatcher, Basic_StringMatcher]
+
+    # version facilitating use of isinstance internally
+    StringMatcher_aslist = (re.Pattern, Basic_StringMatcher, Duck_StringMatcher)
+else:
+
+    Duck_StringMatcher = Basic_StringMatcher
+
+    StringMatcher = Union[re.Pattern, Basic_StringMatcher]
+    """ Either a re.Pattern or a type that satisfies duck typing requirements
+    for matching strings
+    """
+
+    # version facilitating use of isinstance internally
+    StringMatcher_aslist = (re.Pattern, Basic_StringMatcher)
+
+GlobElt = Union[str, StringMatcher]
+""" Type alias for a glob sequence element
+"""
+
+Glob = Union[str, Sequence[GlobElt]]
 """Type alias for glob parameters."""
 
 Path = Union[str, Sequence[PathSegment]]

--- a/dpath/version.py
+++ b/dpath/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.1.4"
+VERSION = "2.2.0"

--- a/flake8.ini
+++ b/flake8.ini
@@ -3,3 +3,10 @@ filename=
     setup.py,
     dpath/,
     tests/
+
+ignore= 
+    W503, 
+    E501,
+    E722
+
+# Note: tox.ini ignore specs have higher priority than this

--- a/test-utils/nose_runner
+++ b/test-utils/nose_runner
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Allow to run nose2 tests with predefined variables as defined in options.py
+#
+# (C) A.Lichnewsky, 2022
+
+import nose2
+import sys
+from dpath import options as OPTS
+import argparse
+
+
+def do_main():
+    description = """
+    This runs nose2 testframe giving the user the ability to set options
+          and in particular DPATH_ACCEPT_RE_REGEXP
+
+    Usage:
+            PYTHONPATH=<as appropriate> nose_runner [-d] [-E] [-K] [-D <val>]  [-s <test directory>] <test-specs>
+
+    Flags:
+    """
+
+    argLineParser = argparse.ArgumentParser(description=description,
+                                            formatter_class=argparse.RawTextHelpFormatter)
+    argLineParser.add_argument("-d", "--debug", action="store_true", dest="doDebug",
+                               help="Debug messages on stderr"),
+
+    argLineParser.add_argument("-E", "--extended", action="store_true", dest="doExtendedPath",
+                               help="Enable regexp extended paths")
+
+    argLineParser.add_argument("-K", "--emptyStringKeys", action="store_true", dest="doEmptyStringKeys",
+                               help="Enable regexp extended paths")
+
+    argLineParser.add_argument("-D", "--duckTyping", dest="duckTyping", action="store_true",
+                               help="Enable support for PEP544 duck typing (if available), default: enabled")
+
+    argLineParser.add_argument("-N", "--noDuckTyping", dest="duckTyping", action="store_false",
+                               help="Disable support for PEP544 duck typing")
+
+    argLineParser.add_argument("-v", "--verbose",  action="store_true",  dest="noseVerbose",
+                               help="Request nose prints tests entered and result")
+
+    argLineParser.add_argument("-s", "--StartDir", dest="startDir", metavar="FILE",
+                               help="Directory to start nose2 discovery")
+
+    argLineParser.add_argument('test_specs',nargs="?", help="test specifications for nose2")
+
+    try:
+        options = argLineParser.parse_args()
+        if options.doDebug:
+            print(repr(options), file=sys.stderr)
+
+        if options.doExtendedPath:
+            OPTS.DPATH_ACCEPT_RE_REGEXP = True
+
+        if options.doEmptyStringKeys:
+            OPTS.ALLOW_EMPTY_STRING_KEYS = True
+
+        if options.duckTyping is not None:
+            OPTS.PEP544_PROTOCOL_AVAILABLE = options.duckTyping
+
+    except Exception:
+        print("Quitting because of error(s)", file=sys.stderr)
+
+        sys.exit(1)
+
+    sys.argv = [el for el in sys.argv if not (el in ("-d", "-K", "-E", "-D", "-N"))]
+
+    if options.doDebug:
+        print(f"Accept extended regexp:{OPTS.DPATH_ACCEPT_RE_REGEXP}", file=sys.stderr)
+        print(f"Allow empty string keys:{OPTS.ALLOW_EMPTY_STRING_KEYS}", file=sys.stderr)
+        print(f"PEP544 duck_typing supported:{OPTS.PEP544_PROTOCOL_AVAILABLE}", file=sys.stderr)
+        print(f"Start discovery at:{options.startDir}", file=sys.stderr)
+
+        print(f"Nose2.discover arglist:{sys.argv}")
+
+    ret = nose2.discover()
+    print("Tests return cc={ret}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    do_main()

--- a/test-utils/py_path_checker
+++ b/test-utils/py_path_checker
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+#
+# Check PYTHONPATH in relation with using PyPy3
+#
+# (C) A.Lichnewsky, 2022
+#
+
+# Object:
+#   On some installations, pypy3 does not search installation paths as
+#   extensively as python3, so that codes do not work. This is easily
+#   corrected using PYTHONPATH, once the required paths are known
+#
+#   This programs displays path where certain modules are to be found
+# -------------------------------------------------------------------------
+
+# minimum set of imports
+import sys
+import os
+import fnmatch
+import glob
+import argparse
+import importlib
+import re
+
+modules_not_imported = []
+
+
+def do_checks(nameList):
+    "Check if modules in nameList may be imported"
+    for modname in nameList:
+        print(f"trying module {modname}", file=sys.stderr)
+        try:
+            importlib.import_module(modname)
+        except Exception as err:
+            print(f"Error when importing '{modname}':{err}")
+            modules_not_imported.append(modname)
+
+
+def do_check_paths(nameList, pathList=sys.path):
+    "Look in pathList for modules in nameList"
+    print(f"Looking in sys.path for {nameList}", file=sys.stderr)
+    count = 0
+    for p in pathList:
+        print(f"Searching path:\t{p}", file=sys.stderr)
+        for root, dirs, files in os.walk(p):
+            for sname in nameList:
+                for name in files:
+                    mname = sname + ".py"
+                    if fnmatch.fnmatch(name, mname):
+                        count += 1
+                        print(f"\t\tFound:{os.path.join(root, name)}\tmatching:{mname}",
+                              file=sys.stderr)
+
+                if (len(dirs) > 1) or (len(dirs) == 1 and "__pycache__" not in dirs):
+                    if sname in dirs:
+                        count += 1
+                        print(f"\tFound module dir {os.path.join(root, name)}\tmatching:{sname}", file=sys.stderr)
+
+    return count
+
+
+piplist_str = r"(?P<pkgname>[A-Za-z]\S+)\s+" \
+    + r"(?P<version>\S+)\s+"       \
+    + r"(?P<path>\S+)\s+"          \
+    + r"(?P<installer>\S+).*"
+
+piplist_rex = None
+try:
+    piplist_rex = re.compile(piplist_str)
+except Exception as err:
+    print(f"In re.regex=\"{piplist_str}\"", file=sys.stderr)
+    print(f"Error:{err}", file=sys.stderr)
+    raise
+
+
+def do_check_pip_installs():
+    "Inform on pip installed modules as returned by command 'pip list -v'"
+    collect = {}
+    with os.popen("pip list -v") as pipe:
+        first = True
+        for line in pipe:
+            match = piplist_rex.match(line)
+            if match and not first:
+                d = match.groupdict()
+                p = d["path"]
+                if p in collect:
+                    collect[p].append(d)
+                else:
+                    collect[p] = [d]
+
+            first = False
+
+    print("Packages known to pip", file=sys.stderr)
+    for p, v in collect.items():
+        r = ",\t".join(("/".join((elv["pkgname"], elv["version"])) for elv in v))
+        print(f"{p}\t{r}\n", file=sys.stderr)
+
+
+usual_paths = (
+    "/usr/local/lib/python*/dist-packages",
+    "/usr/local/lib/pypy*/dist-packages",
+    "/usr/lib/python*",
+    "usr/lib/pypy*",
+    os.path.expanduser("~") + "/.local/lib/py*"
+)
+
+
+def do_check_usual(nameList, verbose=False):
+    "Inform on modules installed in path (glob'ed)"
+    collect = set()
+    for path in usual_paths:
+        if verbose:
+            print(f"Path:{path}", file=sys.stderr)
+        for p in glob.iglob(path):
+            if verbose:
+                print(f"\tPath: {p}", file=sys.stderr)
+            collect.add(p)
+    fmtlist = '\n\t'.join(sorted(collect))
+
+    if len (nameList) == 0 :
+        print(f"Collected paths from 'Usual Suspects':\n\t{fmtlist}\n")
+    else:
+        print(f"Searching in paths from  'Usual Suspects':")        
+        do_check_paths(nameList, pathList=collect)
+
+
+def do_main():
+    description = """
+    This explores the library search paths, looking for module installation
+
+    Usage:nose_pypychecker [-d] [-v] [-h] [-P] [-U]  [-M <module> ...]
+
+    Default for -M: empty list
+    """
+
+    argLineParser = argparse.ArgumentParser(description=description,
+                                            formatter_class=argparse.RawTextHelpFormatter)
+    argLineParser.add_argument("-d", "--debug", action="store_true", dest="doDebug",
+                               help="Adds debug messages on stderr"),
+
+    argLineParser.add_argument("-v", "--verbose", action="store_true", dest="verbose",
+                               help="Increase output of commands")
+
+    argLineParser.add_argument("-U", "--usual", action="store_true", dest="usual",
+                               help="Request analysis of usual suspects beyond sys.path")
+
+    argLineParser.add_argument("-P", "--pip", action="store_true", dest="pip",
+                               help="Request analysis of modules installed by pip")
+
+    argLineParser.add_argument("-M", "--module", dest="module", type=str, nargs="+",
+                               help="Request searching for a specific module")
+
+    try:
+        options = argLineParser.parse_args()
+        if options.doDebug:
+            print(f"Options in use:{repr(options)}", file=sys.stderr)
+            print(f"Python interpreter: {sys.executable}")
+
+        if options.module is None:
+            options.module = []
+
+        do_checks(options.module)
+
+        nb = None
+        if len(modules_not_imported) > 0:
+            nb = do_check_paths(modules_not_imported)
+        elif (len(options.module) > 0) or options.verbose:
+            nb = do_check_paths(options.module)
+
+        nb = 0 if (nb is None) else nb
+        print(f"Found {nb} paths leading to a module in search list")
+
+        if options.pip:
+            do_check_pip_installs()
+
+        if options.usual or (len(modules_not_imported) > 0 and not nb):
+            do_check_usual(modules_not_imported, verbose=options.verbose)
+
+    except Exception:
+        print("Quitting because of error(s)", file=sys.stderr)
+        raise
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    do_main()

--- a/tests/test_duck_typing.py
+++ b/tests/test_duck_typing.py
@@ -1,0 +1,260 @@
+#!/usr / bin / env python3
+# -*- coding: utf-8 -*-
+# -*- mode: Python -*-
+#
+# (C) Alain Lichnewsky, 2022
+#
+#     Test for handling structures that mix dicts and lists (possibly other
+#     iterables)
+#
+
+import dpath as DP
+import unittest
+import re
+import sys
+import rapidfuzz
+from dpath.options import isinstance_ext
+
+# check that how the options have been set
+print(f"At entry in test_path_ext DPATH_ACCEPT_RE_REGEXP = {DP.options.DPATH_ACCEPT_RE_REGEXP}", file=sys.stderr)
+
+if not DP.options.DPATH_ACCEPT_RE_REGEXP:
+    print("This test doesn't make sense with DPATH_ACCEPT_RE_REGEXP = False", file=sys.stderr)
+    DP.options.DPATH_ACCEPT_RE_REGEXP = True  # enable re.regexp support in path expr.
+
+
+print(f"PEP544_PROTOCOL_AVAILABLE={DP.options.PEP544_PROTOCOL_AVAILABLE}", file=sys.stderr)
+
+
+class TestLangProc(unittest.TestCase):
+    """This tests the language processor support of 'typing' module  (Protocol,
+    runtime_checkable), and the abilty to test types """
+
+    def test1(self):
+        if not DP.options.PEP544_PROTOCOL_AVAILABLE:
+            print("Test1 PEPS544 Protocol not available", file=sys.stderr)
+
+        class Anagram():
+            def __init__(self, s):
+                self.ref = "".join(sorted(s))
+
+            def match(self, st):
+                retval = True if "".join(sorted(st)) == self.ref else None
+                return retval
+
+        ana = Anagram("sire")
+        test_cases = (
+            (ana, Anagram, True),
+            (ana, DP.types.Duck_StringMatcher, True),
+            (ana, DP.types.StringMatcher_aslist, True),
+            ("ana", Anagram, False),
+            ("ana", DP.types.Duck_StringMatcher, False),
+            ("ana", DP.types.StringMatcher_aslist, False),
+            (re.compile("ana"), DP.types.Duck_StringMatcher, True),
+            (re.compile("ana"), DP.types.StringMatcher_aslist, True),
+            (re.compile("ana"), DP.types.Basic_StringMatcher, False),
+        )
+        success = True
+        for (o, c, e) in test_cases:
+            r = isinstance_ext(o, c)
+            exp = "OK" if (e == r) else "Unexpected"
+            print(f"{exp} isinstance({o},{c}) returns {r} expected {e}",
+                  file=sys.stderr)
+            if (e != r):
+                success = False
+        assert success
+        print("Performed TestLangProc", file=sys.stderr)
+
+
+class TestBasics(unittest.TestCase):
+    """ This tests mixing lists with dicts, inspired by Issue #178
+    """
+
+    tble = [{'info': {'label': 'a',
+                      'placeholder': 'A',
+                      'value': 'some text'}
+             },
+            {'info': {'label': 'b',
+                      'placeholder': 'B',
+                      'value': ''}},
+            {'info': {'label': 'c',
+                      'placeholder': 'C',
+                      'value': ''}},
+            {2: [{'a': "A", 'b': "B"},
+                 {'aa': "AA", 'bb': "BB"}]}
+            ]
+
+    mydict = {"first": [{'info': {'label': 'a',
+                                  'placeholder': 'A',
+                                  'value': 'some text'}
+                         },
+                        {'info': {'label': 'b',
+                                  'placeholder': 'B',
+                                  'value': ''}},
+                        {'info': {'label': 'c',
+                                  'placeholder': 'C',
+                                  'value': ''}}],
+              2: [{'a': "A", 'b': "B"},
+                  {'aa': "AA", 'bb': "BB"}
+                  ]
+              }
+
+    def testtypes(self):
+        """ Test types
+        """
+        print("Entered TestBasics.testtypes", file=sys.stderr)
+
+        str1 = "a string"
+        if isinstance_ext(str1, DP.types.Duck_StringMatcher):
+            raise RuntimeError("A string should not be accepted as a StringMatcher")
+
+        rex = re.compile(r"\d+")
+        assert isinstance_ext(rex, DP.types.Duck_StringMatcher)
+
+        class Anagram():
+            def __init__(self, s):
+                self.ref = "".join(sorted(s))
+
+            def match(self, st):
+                retval = True if "".join(sorted(st)) == self.ref else None
+                return retval
+
+        class Weird():
+            def __init__(self, s):
+                self.s = s
+
+        class Bad():
+            pass
+
+        print(f"PEP544_PROTOCOL_AVAILABLE={DP.options.PEP544_PROTOCOL_AVAILABLE}", file=sys.stderr)
+        ana = Anagram("tryit")
+        assert isinstance_ext(ana, DP.types.Duck_StringMatcher)
+        catAna = isinstance_ext(ana, DP.types.Duck_StringMatcher)
+        print(f"Anagram is instance Duck_StringMatcher={catAna}", file=sys.stderr)
+        catWeird = isinstance_ext(Weird("oh"), DP.types.Duck_StringMatcher)
+        print(f"Weird is instance Duck_StringMatcher={catWeird}", file=sys.stderr)
+        catBad = isinstance_ext(Bad(), DP.types.Duck_StringMatcher)
+        print(f"Bad is instance Duck_StringMatcher={catBad}", file=sys.stderr)
+
+    def test1(self):
+        """ Test1: reference, test extended glob with embedded re.regex
+        """
+        print("Entered test1", file=sys.stderr)
+
+        mydict = TestBasics.mydict
+
+        r1 = DP.search(mydict, '**/placeholder')
+        r2 = DP.search(mydict, '**/{plac\\S+r$}')
+        assert r1 == r2
+
+    def test2(self):
+        """ Test2: using a StringMatcher duck typed class
+        """
+        print("Entered test2", file=sys.stderr)
+
+        class MySM():
+            def match(self, st):
+                return st == "placeholder"
+
+        mydict = TestBasics.mydict
+
+        r1 = DP.search(mydict, '**/placeholder', afilter=lambda x: 'C' == x)
+        r2 = DP.search(mydict, ['**', MySM()], afilter=lambda x: 'C' == x)
+        r3 = DP.search(mydict, '**/{plac\\S+r$}', afilter=lambda x: 'C' == x)
+
+        assert r1 == r2
+        assert r1 == r3
+
+    def test3(self):
+        """ Test3: using a StringMatcher (duck typed or derivative) class
+        """
+        print("Entered test3 (anagram)", file=sys.stderr)
+        print(f"PEP544_PROTOCOL_AVAILABLE={DP.options.PEP544_PROTOCOL_AVAILABLE}", file=sys.stderr)
+
+        if DP.options.PEP544_PROTOCOL_AVAILABLE:
+            class Anagram():
+                def __init__(self, s):
+                    self.ref = "".join(sorted(s))
+
+                def match(self, st):
+                    retval = True if "".join(sorted(st)) == self.ref else None
+                    return retval
+        else:
+            class Anagram(DP.types.Basic_StringMatcher):
+                def __init__(self, s):
+                    self.ref = "".join(sorted(s))
+
+                def match(self, st):
+                    retval = True if "".join(sorted(st)) == self.ref else None
+                    return retval
+
+        mydict = TestBasics.mydict
+
+        r1 = DP.search(mydict, "**/label")
+        r2 = DP.search(mydict, ['**', Anagram("bella")])
+        print(f"Explicit {r1}", file=sys.stderr)
+        print(f"Anagram {r2}", file=sys.stderr)
+        expected = {'first': [{'info': {'label': 'a'}},
+                              {'info': {'label': 'b'}},
+                              {'info': {'label': 'c'}}]}
+        assert r1 == r2
+        assert r1 == expected
+
+    def test4(self):
+        """ Test4: using a StringMatcher (duck typed or derivative) class (with RapidFuzz pkg
+            https://github.com/maxbachmann/RapidFuzz)
+        """
+        print("Entered test4", file=sys.stderr)
+
+        class Approx():
+            def __init__(self, s, quality=90):
+                self.ref = s
+                self.quality = quality
+
+            def match(self, st):
+                fratio = rapidfuzz.fuzz.ratio(st, self.ref)
+                retval = True if fratio > self.quality else None
+                return retval
+
+        mydict = TestBasics.mydict
+
+        r1 = DP.search(mydict, "**/placeholder")
+        r2 = DP.search(mydict, ['**', Approx("placecolder")])
+        r3 = DP.search(mydict, ['**', Approx("acecolder", 75)])
+        print(f"Explicit {r1}", file=sys.stderr)
+        print(f"Approx {r2}", file=sys.stderr)
+        print(f"Approx {r3}", file=sys.stderr)
+        expected = {'first': [{'info': {'placeholder': 'A'}},
+                              {'info': {'placeholder': 'B'}},
+                              {'info': {'placeholder': 'C'}}]}
+        assert r1 == r2
+        assert r1 == r3
+        assert r1 == expected
+
+
+if __name__ == "__main__":
+
+    # To debug under the Python debugger:
+    # A) Use a command like:
+    #    PYTHONPATH="../dpath-source"  python3 -m pdb \
+    #             ../dpath-source/tests/test_various_exts.py
+    # B) Adapt and uncomment the following
+    # ts = TestLangProc()
+    # ts.test1()
+
+    # ts = TestBasics()
+    # ts.testtypes()
+    # ts.test1()
+    # ts.test2()
+    # ts.test3()
+    # ts.test4()
+
+    print("""
+    a) This is intended to be run under nose2 and not standalone !
+    b) Python script nose_runner (in test-utils) adds to nose2 capability to set dpath.options
+
+    Exiting
+    """,
+          file=sys.stderr
+          )
+    sys.exit(2)

--- a/tests/test_get_values.py
+++ b/tests/test_get_values.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 import time
 
-import mock
+from unittest.mock import patch
 from nose2.tools.such import helper
 
 import dpath
@@ -109,7 +109,7 @@ def test_values():
     assert 2 in ret
 
 
-@mock.patch('dpath.search')
+@patch('dpath.search')
 def test_values_passes_through(searchfunc):
     searchfunc.return_value = []
 
@@ -190,7 +190,7 @@ def test_non_leaf_leaf():
     # Data classes should also be retrievable:
     try:
         import dataclasses
-    except:
+    except Exception:
         return
 
     @dataclasses.dataclass

--- a/tests/test_path_ext.py
+++ b/tests/test_path_ext.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -*- mode: Python -*-
+#
+# (C) Alain Lichnewsky, 2021
+#
+#     Much code copied from test_segments.py
+#
+import os
+import sys
+import re
+
+
+import unittest
+from hypothesis import given, assume, settings, HealthCheck
+import hypothesis.strategies as st
+
+from dpath import options
+import dpath.segments as api
+import dpath.options
+
+# check that how the options have been set
+print(f"At entry in test_path_ext DPATH_ACCEPT_RE_REGEXP = {dpath.options.DPATH_ACCEPT_RE_REGEXP}", file=sys.stderr)
+
+if not dpath.options.DPATH_ACCEPT_RE_REGEXP:
+    print("This test doesn't make sense with DPATH_ACCEPT_RE_REGEXP = False", file=sys.stderr)
+    dpath.options.DPATH_ACCEPT_RE_REGEXP = True  # enable re.regexp support in path expr.
+
+# enables to modify some globals
+MAX_SAMPLES = None
+if __name__ == "__main__":
+    if "-v" in sys.argv:
+        MAX_SAMPLES = 20
+        MAX_LEAVES = 7
+
+
+settings.register_profile("default", suppress_health_check=(HealthCheck.too_slow,))
+settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'default'))
+if MAX_SAMPLES is None:
+    MAX_LEAVES = 20
+    MAX_SAMPLES = 300
+
+ALPHABET = ('A', 'B', 'C', ' ')
+ALPHABETK = ('a', 'b', 'c', '-')
+
+random_key_int = st.integers(0, 10)
+random_key_str = st.text(alphabet=ALPHABETK, min_size=2)
+random_key = random_key_str | random_key_int
+random_segments = st.lists(random_key, max_size=4)
+random_leaf = random_key_int | st.text(alphabet=ALPHABET, min_size=2)
+
+
+if options.ALLOW_EMPTY_STRING_KEYS:
+    random_thing = st.recursive(
+        random_leaf,
+        lambda children: (st.lists(children, max_size=3)
+                          | st.dictionaries(st.binary(max_size=5)
+                                            | st.text(alphabet=ALPHABET), children)),
+        max_leaves=MAX_LEAVES)
+else:
+    random_thing = st.recursive(
+        random_leaf,
+        lambda children: (st.lists(children, max_size=3)
+                          | st.dictionaries(st.binary(min_size=1, max_size=5)
+                                            | st.text(min_size=1, alphabet=ALPHABET),
+                          children)),
+        max_leaves=MAX_LEAVES)
+
+random_node = random_thing.filter(lambda thing: isinstance(thing, (list, dict)))
+
+if options.ALLOW_EMPTY_STRING_KEYS:
+    random_mutable_thing = st.recursive(
+        random_leaf,
+        lambda children: (st.lists(children, max_size=3) | st.text(alphabet=ALPHABET),
+                          children),
+        max_leaves=MAX_LEAVES)
+else:
+    random_mutable_thing = st.recursive(
+        random_leaf,
+        lambda children: (st.lists(children, max_size=3)
+                          | st.dictionaries(st.text(alphabet=ALPHABET, min_size=1),
+                          children)),
+        max_leaves=MAX_LEAVES)
+
+
+random_mutable_node = random_mutable_thing.filter(lambda thing: isinstance(thing,
+                                                                           (list, dict)))
+
+
+@st.composite
+def mutate(draw, segment):
+    # Convert number segments.
+    segment = api.int_str(segment)
+
+    # Infer the type constructor for the result.
+    kind = type(segment)
+
+    # Produce a valid kind conversion for our wildcards.
+    if isinstance(segment, bytes):
+        def to_kind(v):
+            try:
+                return bytes(v, 'utf-8')
+            except Exception:
+                return kind(v)
+    else:
+        def to_kind(v):
+            return kind(v)
+
+    # Convert to an list of single values.
+    converted = []
+    for i in range(len(segment)):
+        # This carefully constructed nonsense to get a single value
+        # is necessary to work around limitations in the bytes type
+        # iteration returning integers instead of byte strings of
+        # length 1.
+        c = segment[i:i + 1]
+
+        # Check for values that need to be escaped.
+        if c in tuple(map(to_kind, ('*', '?', '[', ']'))):
+            c = to_kind('[') + c + to_kind(']')
+
+        converted.append(c)
+
+    # Start with a non-mutated result.
+    result = converted
+
+    # 50/50 chance we will attempt any mutation.
+    change = draw(st.sampled_from((True, False)))
+    if change:
+        result = []
+
+        # For every value in segment maybe mutate, maybe not.
+        for c in converted:
+            # If the length isn't 1 then, we know this value is already
+            # an escaped special character. We will not mutate these.
+            if len(c) != 1:
+                result.append(c)
+            else:
+                # here the character is mutated to ? or * with 1/3 proba
+                result.append(draw(st.sampled_from((c, to_kind('?'), to_kind('*')))))
+
+    combined = kind().join(result)
+
+    # If we by chance produce the star-star result, then just revert
+    # back to the original converted segment. This is not the mutation
+    # you are looking for.
+    if combined == to_kind('**'):
+        combined = kind().join(converted)
+
+    return combined
+
+
+@st.composite
+def random_segments_with_glob(draw):
+    segments = draw(random_segments)
+    glob = list(map(lambda x: draw(mutate(x)), segments))
+
+    # 50/50 chance we will attempt to add a star-star to the glob.
+    use_ss = draw(st.sampled_from((True, False)))
+    if use_ss:
+        # Decide if we are inserting a new segment or replacing a range.
+        insert_ss = draw(st.sampled_from((True, False)))
+        if insert_ss:
+            index = draw(st.integers(0, len(glob)))
+            glob.insert(index, '**')
+        else:
+            start = draw(st.integers(0, len(glob)))
+            stop = draw(st.integers(start, len(glob)))
+            glob[start:stop] = ['**']
+
+    return (segments, glob)
+
+
+@st.composite
+def random_segments_with_nonmatching_glob(draw):
+    (segments, glob) = draw(random_segments_with_glob())
+
+    # Generate a segment that is not in segments.
+    invalid = draw(random_key.filter(lambda x: x not in segments and x not in ('*', '**')))
+
+    # Do we just have a star-star glob? It matches everything, so we
+    # need to replace it entirely.
+    if len(glob) == 1 and glob[0] == '**':
+        glob = [invalid]
+    # Do we have a star glob and only one segment? It matches anything
+    # in the segment, so we need to replace it entirely.
+    elif len(glob) == 1 and glob[0] == '*' and len(segments) == 1:
+        glob = [invalid]
+    # Otherwise we can add something we know isn't in the segments to
+    # the glob.
+    else:
+        index = draw(st.integers(0, len(glob)))
+        glob.insert(index, invalid)
+
+    return (segments, glob)
+
+
+def checkSegGlob(segments, glob):
+    """ simple minded check that the translation done in random_segments_with_re_glob
+        does not suppress matching; just do not inspect in the case where a "**" has been
+        put in glob.
+    """
+    if "**" in glob:
+        return
+    zipped = zip(segments, glob)
+    for (s, g) in zipped:
+        if isinstance(s, int):
+            continue
+        if isinstance(g, re.Pattern):
+            m = g.match(s)
+        elif isinstance(g, str) and not g == "**":
+            m = re.match(g, s)
+        else:
+            raise NotImplementedError(f"unexpected type for g=({type(g)}){g}")
+        if not m:
+            print(f"Failure in checkSegGlob {(s,g)} type(g)={type(g)}", file=sys.stderr)
+            raise RuntimeError("{repr(s)}' does not match regexp:{repr(g)}")
+
+# exclude translation if too many *, to avoid too large cost in matching
+# '*' -> '.*'  # see glob
+# '?' -> '.'   # see glob
+#                Recall that bash globs are described at URL:
+#                  https://man7.org/linux/man-pages/man7/glob.7.html
+
+
+rex_translate = re.compile("([*])[*]*")
+rex_translate2 = re.compile("([?])")
+rex_isnumber = re.compile(r"\d+")
+
+
+@st.composite
+def random_segments_with_re_glob(draw):
+    """ Transform some globs with equivalent re.regexprs, to test the use of regexprs
+    """
+    (segments, glob) = draw(random_segments_with_glob())
+    glob1 = []
+    for g in glob:
+        if g == "**" or not isinstance(g, str) or rex_isnumber.match(g):
+            glob1.append(g)
+            continue
+        try:
+            g0 = rex_translate.sub(".\\1", g)
+            g0 = rex_translate2.sub(".", g0)
+            g1 = re.compile("^" + g0 + "$")
+            if not g1.match(g):
+                g1 = g
+        except Exception:
+            sys.stderr.write("Unable to re.compile:({})'{}' from '{}'\n".format(type(g1), g1, g))
+            g1 = g
+        glob1.append(g1)
+
+    checkSegGlob(segments, glob1)
+    return (segments, glob1)
+
+
+@st.composite
+def random_segments_with_nonmatching_re_glob(draw):
+    """ Transform some globs with equivalent re.regexprs, to test the use of regexprs
+    """
+    (segments, glob) = draw(random_segments_with_nonmatching_glob())
+    glob1 = []
+    for g in glob:
+        if g == "**" or not isinstance(g, str):
+            glob1.append(g)
+            continue
+        try:
+            g0 = rex_translate.sub(".\\1", g)
+            g0 = rex_translate2.sub(".", g0)
+            g1 = re.compile("^" + g0 + "$")
+        except Exception:
+            sys.stderr.write("(non-matching):Unable to re.compile:({}){}".format(type(g), g))
+            g1 = g
+        glob1.append(g1)
+
+    return (segments, glob1)
+
+
+@st.composite
+def random_walk(draw):
+    """ return a (node, (segment, value))
+        where node is arbitrary tree,
+             (segment, value) is a valid  pair drawn from the return of
+             api.walk(node), wich generates them    all.
+    """
+    node = draw(random_mutable_node)
+    found = tuple(api.walk(node))
+    assume(len(found) > 0)
+    (cr, dr) = draw(st.sampled_from(found))
+    if dr in (int, str):
+        dr = (dr,)
+    return (node, (cr, dr))
+
+
+def setup():
+    # Allow empty strings in segments.
+    options.ALLOW_EMPTY_STRING_KEYS = True
+
+
+def teardown():
+    # Revert back to default.
+    options.ALLOW_EMPTY_STRING_KEYS = False
+
+
+#
+# Run under unittest
+#
+class TestEncoding(unittest.TestCase):
+    DO_DEBUG_PRINT = False
+
+    @settings(max_examples=MAX_SAMPLES)
+    @given(random_segments_with_re_glob())
+    def test_match_re(self, pair):
+        '''
+        Given segments and a known good glob, match should be True.
+        '''
+        (segments, glob) = pair
+        assert api.match(segments, glob) is True
+        if TestEncoding.DO_DEBUG_PRINT:
+            sys.stderr.write("api.match: segments:{} , glob:{}\n".format(segments, glob))
+
+    @settings(max_examples=MAX_SAMPLES)
+    @given(random_segments_with_nonmatching_re_glob())
+    def test_match_nonmatching_re(self, pair):
+        '''
+        Given segments and a known bad glob, match should be False.
+        '''
+        (segments, glob) = pair
+        assert api.match(segments, glob) is False
+        if TestEncoding.DO_DEBUG_PRINT:
+            sys.stderr.write("api.match:non match OK: segments:{}, glob:{}\n".format(segments, glob))
+
+
+if __name__ == "__main__":
+    if "-h" in sys.argv:
+        description = """\
+This may run either under tox or standalone. When standalone
+flags -h and -v are recognized, other flags are dealt with by unittest.main
+and may select test cases.
+
+Flags:
+    -h print this help and quit
+    -V print information messages on stderr; also reduces MAX_SAMPLES to 50
+    -v handled by unittest framework
+Autonomous CLI syntax:
+    python3 [-h] [-v] [TestEncoding[.<testname>]]
+
+    e.g.     python3 TestEncoding.test_match_re
+"""
+        print(description)
+        sys.exit(0)
+
+    if "-V" in sys.argv:
+        sys.argv = [x for x in sys.argv if x != "-V"]
+        TestEncoding.DO_DEBUG_PRINT = True
+        sys.stderr.write("Set verbose mode\n")
+
+    sys.stderr.write(f"Starting tests in test_path_exts with args {sys.argv}")
+    unittest.main()

--- a/tests/test_various_exts.py
+++ b/tests/test_various_exts.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# -*- mode: Python -*-
+#
+# (C) Alain Lichnewsky, 2022
+#
+#     Test many functionalities that use path specifications for support of extended specs with re.regex
+#
+import sys
+import re
+
+from copy import copy
+
+import unittest
+import dpath as DP
+
+# check that how the options have been set
+print(f"At entry in test_path_ext DPATH_ACCEPT_RE_REGEXP = {DP.options.DPATH_ACCEPT_RE_REGEXP}", file=sys.stderr)
+
+if not DP.options.DPATH_ACCEPT_RE_REGEXP:
+    print("This test doesn't make sense with DPATH_ACCEPT_RE_REGEXP = False", file=sys.stderr)
+    DP.options.DPATH_ACCEPT_RE_REGEXP = True  # enable re.regexp support in path expr.
+
+
+# one class per function to be tested
+class SampleDicts():
+
+    def build(self):
+        self.d1 = {
+            "a001": {
+                "b2": {
+                    "c1.2": {
+                        "d.dd": 0,
+                        "e.ee": 1,
+                        "f.f0": 2,
+                    },
+                },
+            },
+        }
+
+        self.specs1 = ([re.compile(".*")],
+                       [re.compile("[a-z]+$")],
+                       ["*", re.compile(".*")],
+                       ["*", "*", re.compile(".*")],
+                       ["*", re.compile("[a-z]+\\d+$")],
+                       ["*", re.compile("[a-z]+[.][a-z]+$")],
+                       ["**", re.compile(".*")],
+                       ["**", re.compile("[a-z]+\\d+$")],
+                       ["**", re.compile("[a-z]+[.][a-z]+$")]
+                       )
+
+        self.specs1Pairs = (([re.compile(".*")], ("a001",)),
+                            ([re.compile("[a-z]+$")], None),
+                            (["*", re.compile(".*")], ("a001/b2",)),
+                            (["*", "*", re.compile(".*")], ("a001/b2/c1.2",)),
+                            (["*", re.compile("[a-z]+\\d+$")], ("a001/b2",)),
+                            (["*", re.compile("[a-z]+[.][a-z]+$")], None),
+                            (["**", re.compile(".*")],
+                            ("a001", "a001/b2", "a001/b2/c1.2", "a001/b2/c1.2/d.dd",
+                             "a001/b2/c1.2/e.ee", "a001/b2/c1.2/f.f0")),
+                            (["**", re.compile("[a-z]+\\d+$")], ("a001", "a001/b2")),
+                            (["**", re.compile("[a-z]+[.][a-z]+$")],
+                            ("a001/b2/c1.2/d.dd", "a001/b2/c1.2/e.ee"))
+                            )
+
+        self.specs1GetPairs = (([re.compile(".*")], {'b2': {'c1.2': {'d.dd': 0, 'e.ee': 1, 'f.f0': 2}}}),
+                               ([re.compile("[a-z]+$")], ('*NONE*',)),
+                               (["*", re.compile(".*")], {'c1.2': {'d.dd': 0, 'e.ee': 1, 'f.f0': 2}}),
+                               (["*", "*", re.compile(".*")], {'d.dd': 0, 'e.ee': 1, 'f.f0': 2}),
+                               (["*", re.compile("[a-z]+\\d+$")], {'c1.2': {'d.dd': 0, 'e.ee': 1, 'f.f0': 2}}),
+                               (["*", re.compile("[a-z]+[.][a-z]+$")], ('*NONE*',)),
+                               (["**", re.compile(".*")], "*FAIL*"),
+                               (["**", re.compile("[a-z]+\\d+$")], "*FAIL*"),
+                               (["**", re.compile("[a-z]+[.][a-z]+$")], "*FAIL*"),
+                               )
+
+        self.d2 = {"Name": "bridge",
+                   "Id": "333d22b3724",
+                   "Created": "2022-12-08T09:02:33.360812052+01:00",
+                   "Scope": "local",
+                   "Driver": "bridge",
+                   "EnableIPv6": False,
+                   "IPAM": {
+                           "Driver": "default",
+                           "Options": None,
+                           "Config":
+                           {
+                               "Subnet": "172.17.0.0/16",
+                               "Gateway": "172.17.0.1"
+                           }
+                   },
+                   "Internal": False,
+                   "Attachable": False,
+                   "Ingress": False,
+                   "ConfigFrom": {
+                       "Network": ""
+                   },
+                   "ConfigOnly": False,
+                   "Containers": {
+                       "199c590e8f13477": {
+                           "Name": "al_dpath",
+                           "EndpointID": "3042bbe16160a63b7",
+                           "MacAddress": "02:34:0a:11:10:22",
+                           "IPv4Address": "172.17.0.2/16",
+                           "IPv6Address": ""
+                       }
+                   },
+                   "Options": {
+                       "com.docker.network.bridge.default_bridge": "true",
+                       "com.docker.network.bridge.enable_icc": "true",
+                       "com.docker.network.bridge.enable_ip_masquerade": "true",
+                       "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
+                       "com.docker.network.bridge.name": "docker0",
+                       "com.docker.network.driver.mtu": "1500"
+                   },
+                   "Labels": {}
+                   }
+
+        self.specs2Pairs = ((["*", re.compile("[A-Z][a-z\\d]*$")],
+                             ("IPAM/Driver", "IPAM/Options", "IPAM/Config", "ConfigFrom/Network")),
+                            (["**", re.compile("[A-Z][a-z\\d]*$")],
+                             ("Name", "Id", "Created", "Scope", "Driver", "Internal", "Attachable",
+                                "Ingress", "Containers", "Options", "Labels", "IPAM/Driver", "IPAM/Options",
+                                "IPAM/Config", "IPAM/Config/Subnet", "IPAM/Config/Gateway",
+                                "ConfigFrom/Network", "Containers/199c590e8f13477/Name",
+                                "Containers/199c590e8f13477/MacAddress")),
+                            (["**", re.compile("[A-Z][A-Za-z\\d]*Address$")],
+                             ("Containers/199c590e8f13477/MacAddress", "Containers/199c590e8f13477/IPv4Address",
+                                "Containers/199c590e8f13477/IPv6Address")),
+                            (["**", re.compile("[A-Za-z]+\\d+$")], ("EnableIPv6",)),
+                            (["**", re.compile("\\d+[.]\\d+")], None),
+
+                            # repeated intentionally using raw strings rather than '\\' escapes
+
+                            (["*", re.compile(r"[A-Z][a-z\d]*$")],
+                             ("IPAM/Driver", "IPAM/Options", "IPAM/Config", "ConfigFrom/Network")),
+                            (["**", re.compile(r"[A-Z][a-z\d]*$")],
+                             ("Name", "Id", "Created", "Scope", "Driver", "Internal", "Attachable",
+                                "Ingress", "Containers", "Options", "Labels", "IPAM/Driver", "IPAM/Options",
+                                "IPAM/Config", "IPAM/Config/Subnet", "IPAM/Config/Gateway",
+                                "ConfigFrom/Network", "Containers/199c590e8f13477/Name",
+                                "Containers/199c590e8f13477/MacAddress")),
+                            (["**", re.compile(r"[A-Z][A-Za-z\d]*Address$")],
+                             ("Containers/199c590e8f13477/MacAddress", "Containers/199c590e8f13477/IPv4Address",
+                                "Containers/199c590e8f13477/IPv6Address")),
+                            (["**", re.compile(r"[A-Za-z]+\d+$")], ("EnableIPv6",)),
+                            (["**", re.compile(r"\d+[.]\d+")], None)
+                            )
+
+        self.specs3Pairs = (("**/{[^A-Za-z]{2}$}", ("Id",)),
+                            ("*/{[A-Z][A-Za-z\\d]*$}", ("Name", "Id", "Created", "Scope", "Driver", "Internal",
+                                                        "Attachable", "Ingress", "Containers", "Options", "Labels",
+                                                        "IPAM/Driver", "IPAM/Options", "IPAM/Config", "IPAM/Config/Subnet",
+                                                        "IPAM/Config/Gateway", "ConfigFrom/Network", "Containers/199c590e8f13477/Name",
+                                                        "Containers/199c590e8f13477/MacAddress")),
+                            ("**/{[A-Z][A-Za-z\\d]*\\d$}", ("EnableIPv6",)),
+                            ("**/{[A-Z][A-Za-z\\d]*Address$}", ("Containers/199c590e8f13477/MacAddress",
+                                                                "Containers/199c590e8f13477/IPv4Address",
+                                                                "Containers/199c590e8f13477/IPv6Address")),
+
+                            # repeated intentionally using raw strings rather than '\\' escapes
+
+                            (r"**/{[A-Z][A-Za-z\d]*\d$}", ("EnableIPv6",)),
+                            (r"**/{[A-Z][A-Za-z\d]*Address$}", ("Containers/199c590e8f13477/MacAddress",
+                                                                "Containers/199c590e8f13477/IPv4Address",
+                                                                "Containers/199c590e8f13477/IPv6Address")),
+                            )
+        return self
+
+
+class TestSearch(unittest.TestCase):
+
+    def test1(self):
+        print("Entered test1", file=sys.__stderr__)
+        dicts = SampleDicts().build()
+        dict1 = dicts.d1
+        specs = dicts.specs1Pairs
+        for (spec, expect) in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            for (path, value) in DP.search(dict1, spec, yielded=True):
+                print(f"\tpath={path}\tv={value}\n\texpected={expect}",
+                      file=sys.stderr)
+                if path is None:
+                    assert expect is None
+                else:
+                    assert (path in expect)
+            print("\n", file=sys.stderr)
+
+    def test2(self):
+        print("Entered test2", file=sys.__stderr__)
+
+        def afilter(x):
+            # print(f"In afilter x = {x}({type(x)})", file=sys.stderr)
+            if isinstance(x, int):
+                return True
+            return False
+
+        dicts = SampleDicts().build()
+        dict1 = dicts.d1
+        specs = dicts.specs1
+        for spec in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            for ret in DP.search(dict1, spec, yielded=True, afilter=afilter):
+                print(f"\tret={ret}", file=sys.stderr)
+                assert (isinstance(ret[1], int))
+
+    def test3(self):
+        print("Entered test3", file=sys.__stderr__)
+        dicts = SampleDicts().build()
+        dict1 = dicts.d2
+        specs = dicts.specs2Pairs
+        for (spec, expect) in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            for (path, value) in DP.search(dict1, spec, yielded=True):
+                print(f"\tpath={path}\tv={value}", file=sys.stderr)
+                if path is None:
+                    assert expect is None
+                else:
+                    assert (path in expect)
+
+    def test4(self):
+        print("Entered test4", file=sys.__stderr__)
+        dicts = SampleDicts().build()
+        dict1 = dicts.d2
+        specs = dicts.specs3Pairs
+        for (spec, expect) in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            for (path, value) in DP.search(dict1, spec, yielded=True):
+                print(f"\tpath={path}\tv={value}", file=sys.stderr)
+                if path is None:
+                    assert expect is None
+                else:
+                    assert (path in expect)
+
+
+class TestGet(unittest.TestCase):
+
+    def test1(self):
+        print("Entered test1", file=sys.__stderr__)
+
+        dicts = SampleDicts().build()
+        dict1 = dicts.d1
+        specs = dicts.specs1GetPairs
+        for (spec, expect) in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            try:
+                ret = DP.get(dict1, spec, default=("*NONE*",))
+                print(f"\tret={ret}", file=sys.stderr)
+                assert (ret == expect)
+            except Exception as err:
+                print("\t get fails:", err, type(err), file=sys.stderr)
+                assert (expect == "*FAIL*")
+
+
+class TestDelete(unittest.TestCase):
+    def test1(self):
+        print("This is test1", file=sys.stderr)
+        dict1 = {
+            "a": {
+                "b": 0,
+                "12": 0,
+            },
+            "a0": {
+                "b": 0,
+            },
+        }
+
+        specs = (re.compile("[a-z]+$"), re.compile("[a-z]+\\d+$"),
+                 "{[a-z]+\\d+$}")
+        i = 0
+        for spec in specs:
+            dict = copy(dict1)
+            print(f"spec={spec}")
+            print(f"Before deletion dict={dict}", file=sys.stderr)
+            DP.delete(dict, [spec])
+            print(f"After deletion dict={dict}", file=sys.stderr)
+            if i == 0:
+                assert (dict == {"a0": {"b": 0, }, })
+            else:
+                assert (dict == {"a": {"b": 0, "12": 0, }})
+            i += 1
+
+
+class TestView(unittest.TestCase):
+    def test1(self):
+        print("Entered test1", file=sys.__stderr__)
+
+        dicts = SampleDicts().build()
+        dict1 = dicts.d1
+        specs = dicts.specs1
+        for spec in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            for ret in DP.segments.view(dict1, spec):
+                print(f"\tview returns:{ret}", file=sys.stderr)
+
+
+class TestMatch(unittest.TestCase):
+    def test1(self):
+        print("Entered test1", file=sys.__stderr__)
+
+        dicts = SampleDicts().build()
+        dict1 = dicts.d1
+        specs = dicts.specs1
+        for spec in specs:
+            print(f"Spec={spec}", file=sys.stderr)
+            if DP.segments.match(dict1, spec):
+                print(f"Spec={spec} matches", file=sys.stderr)
+
+
+if __name__ == "__main__":
+
+    # To debug under the Python debugger:
+    # A) Use a command like:
+    #    PYTHONPATH="../dpath-source"  python3 -m pdb \
+    #             ../dpath-source/tests/test_various_exts.py
+    # B) Adapt and uncomment the following
+    # ts=TestGet()
+    # ts.test1()
+
+    # ts=TestDelete()
+    # ts.test1()
+
+    print("""
+    a) This is intended to be run under nose2 and not standalone !
+    b) Python script nose_runner (in test-utils) adds to nose2 capability to set dpath.options
+       It is also possible to run under pypy using pypy-test
+    Exiting
+    """,
+          file=sys.stderr
+          )
+    sys.exit(2)

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,14 @@
 # and then run "tox" from this directory.
 
 [flake8]
-ignore = E501,E722
+ignore = E501,E722,E721,F401,W503
 
 [tox]
-envlist = pypy37, py38, py39, py310
+envlist = pypy39, py310
 
 [gh-actions]
 python =
-    pypy-3.7: pypy37
-    3.8: py38
-    3.9: py39
+    pypy3.9: pypy39  
     3.10: py310
 
 [testenv]
@@ -21,4 +19,5 @@ deps =
     hypothesis
     mock
     nose2
+    rapidfuzz
 commands = nose2 {posargs}


### PR DESCRIPTION
Hi,
following the approach in previous PRs, this allows to use *user defined match*. 
An example is shown below, more in the README.rst and the tests.

Remarks: 
- this  uses duck typing for ease of use, yet provides a more classical base class/derived class mechanism for language processors ((older) Pythons, Pypy) that do not support the feature
- extends tests
- this uses recent Python developments, but work-around provided for older/non compliant (yet).
       - https://peps.python.org/pep-0604/#isinstance-and-issubclass
       - https://bugs.python.org/issue44529
       - the duck typing technique requires PEP-0544 features

Examples of code

```
class Anagram():
                def __init__(self, s):
                    self.ref = "".join(sorted(s))

                def match(self, st):
                    retval = True if "".join(sorted(st)) == self.ref else None
                    return retval

dpath.search(mydict, ['**', Anagram("bella")
```
   Same example not requiring duck typing, appropriate for Pypy (at this time) and older Pythons

 ```
 class Anagram(DP.types.Basic_StringMatcher):
         def __init__(self, s):
                    self.ref = "".join(sorted(s))

        def match(self, st):
                    retval = True if "".join(sorted(st)) == self.ref else None
                    return retval

dpath.search(mydict, ['**', Anagram("bella")
```