### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@main
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@main
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Setup flake8 annotations
         uses: rbialon/flake8-annotations@v1.1
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         # Match versions specified in tox.ini
-        python-version: ['3.8', '3.9', '3.10', 'pypy-3.7']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.7']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/dpath/version.py
+++ b/dpath/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.1.5"
+VERSION = "2.1.6"

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Typing :: Typed',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 ignore = E501,E722
 
 [tox]
-envlist = pypy37, py38, py39, py310
+envlist = pypy37, py38, py39, py310, py311
 
 [gh-actions]
 python =
@@ -15,6 +15,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
Currently, 3.11 is not listed as supported. This PR adds 3.11 to the testing matrix and updates the relevant classifier in `setup.py`.

<details>
<summary>Motivation</summary>

My apologies, this might be a mess to read, and is probably irrelevant for most readers.

This is part of an attempt to fix installs for [snakemake/snakemake](https://github.com/snakemake/snakemake) >7.x on linux ARM. One of `snakemake`'s dependencies, `yte`, is blocking this by not supporting linux ARM. In the process of updating `yte`, I realized that when migrating from 1.x to 2.x, `dpath` dropped `noarch` support. I believe the lack of that support is blocking `yte`'s support as well.

As such, I'd like to update the [dpath-feedstock](https://github.com/conda-forge/dpath-feedstock/) to ship a `noarch` version. Part of that process requires a constraint to be placed on `dpaths`'s compatible python versions (https://github.com/conda-forge/dpath-feedstock/pull/44). In the interest of making that version constraint as flexible as possible, I'd like to add 3.11 support. `tox` appears to pass all tests in 3.11, so I believe adding support is as simple as adding 3.11 to the testing matrix/updating the pypi badge.
</details>