### PR TITLE
use newer unittest.mock when available

### DIFF
--- a/tests/test_get_values.py
+++ b/tests/test_get_values.py
@@ -2,10 +2,7 @@ import datetime
 import decimal
 import time
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from nose2.tools.such import helper
 

--- a/tests/test_get_values.py
+++ b/tests/test_get_values.py
@@ -2,7 +2,11 @@ import datetime
 import decimal
 import time
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from nose2.tools.such import helper
 
 import dpath


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock