### PR TITLE
Support Empty List Path In get

### DIFF
--- a/dpath/__init__.py
+++ b/dpath/__init__.py
@@ -167,7 +167,7 @@ def get(
     If more than one leaf matches the glob, ValueError is raised. If the glob is
     not found and a default is not provided, KeyError is raised.
     """
-    if glob == "/":
+    if glob == "/" or (type(glob) is not str and len(glob) == 0):
         return obj
 
     globlist = _split_path(glob, separator)

--- a/dpath/__init__.py
+++ b/dpath/__init__.py
@@ -167,7 +167,7 @@ def get(
     If more than one leaf matches the glob, ValueError is raised. If the glob is
     not found and a default is not provided, KeyError is raised.
     """
-    if glob == "/" or (type(glob) is not str and len(glob) == 0):
+    if isinstance(glob, str) and glob == "/" or len(glob) == 0:
         return obj
 
     globlist = _split_path(glob, separator)

--- a/tests/test_get_values.py
+++ b/tests/test_get_values.py
@@ -17,6 +17,9 @@ def test_util_get_root():
     ret = dpath.get(x, '/')
     assert ret == x
 
+    ret = dpath.get(x, [])
+    assert ret == x
+
 
 def test_get_explicit_single():
     ehash = {


### PR DESCRIPTION
Solves Issue #193. Currently, `dpath.get()` works with a path of '/' by returning the value of the object passed in. This behavior is not reflected with an empty list. Now, passing an empty list to `dpath.get()` will behave the same way (returning the root object value).