### PR TITLE
Fix in README.rst: Supply dictionary as first argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -435,7 +435,7 @@ To get around this, you can sidestep the whole "filesystem path" style, and aban
 .. code-block:: python
 
    >>> x = { 'a': {'b/c': 0}}
-   >>> dpath.get(['a', 'b/c'])
+   >>> dpath.get(x, ['a', 'b/c'])
    0
 
 dpath.segments : The Low-Level Backend


### PR DESCRIPTION
This fixes a small bug in the example 'Separator got you down?'.